### PR TITLE
chore: promote golang-gk to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/golang-gk/golang-gk-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/golang-gk/golang-gk-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-16T08:09:52Z"
+  creationTimestamp: "2020-12-16T08:55:26Z"
   deletionTimestamp: null
-  name: 'golang-gk-0.0.1'
+  name: 'golang-gk-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: 921908f486b1db8680cc79206f84f87f97201e06
+        chore: release 0.0.2
+      sha: 0e1a5b1133f2bf004f6a692b370fda08810f7e59
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: b016eb5d57f3c1e37a0d6af88171331efc51cec2
+      sha: f44b6bf6670f9b0eeef67862938b02c6fee60e3e
     - author:
-        email: krishnagokula5e@gmail.com
+        email: 33853819+gokula-krishna-dev@users.noreply.github.com
         name: Gokula Krishna
       branch: master
       committer:
-        email: krishnagokula5e@gmail.com
-        name: Gokula Krishna
-      message: |
-        chore: Jenkins X build pack
-      sha: 35c8b7b0f6a7f9fb091097fb50cb4a2db67c691f
+        email: noreply@github.com
+        name: GitHub
+      message: Update main.go
+      sha: 4e768d92234bcbd4dc6ce3052ab3a3b8d5f560ba
   gitHttpUrl: https://github.com/gokula-krishna-dev/golang-gk
   gitOwner: gokula-krishna-dev
   gitRepository: golang-gk
   name: 'golang-gk'
-  releaseNotesURL: https://github.com/gokula-krishna-dev/golang-gk/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/gokula-krishna-dev/golang-gk/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/golang-gk/golang-gk-golang-gk-deploy.yaml
+++ b/config-root/namespaces/jx-staging/golang-gk/golang-gk-golang-gk-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: golang-gk-golang-gk
   labels:
     draft: draft-app
-    chart: "golang-gk-0.0.1"
+    chart: "golang-gk-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: golang-gk-golang-gk
       containers:
         - name: golang-gk
-          image: "10.104.74.249/gokula-krishna-dev/golang-gk:0.0.1"
+          image: "10.104.74.249/gokula-krishna-dev/golang-gk:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/golang-gk/golang-gk-svc.yaml
+++ b/config-root/namespaces/jx-staging/golang-gk/golang-gk-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: golang-gk
   labels:
-    chart: "golang-gk-0.0.1"
+    chart: "golang-gk-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: golang-gk
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-gk
-  version: 0.0.1
+  version: 0.0.2
   name: golang-gk
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote golang-gk to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge