### PR TITLE
chore: promote py-jx to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/py-jx/py-jx-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/py-jx/py-jx-0.0.1-release.yaml
@@ -1,0 +1,59 @@
+# Source: py-jx/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-16T10:30:23Z"
+  deletionTimestamp: null
+  name: 'py-jx-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: 1dc9cd484542507f0474261f8f82d7bd1639f757
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 5e37097c96fc943849eb2186dd00db68de77ddcc
+    - author:
+        email: krishnagokula5e@gmail.com
+        name: Gokula Krishna
+      branch: master
+      committer:
+        email: krishnagokula5e@gmail.com
+        name: Gokula Krishna
+      message: |
+        new
+      sha: 902eb34dea0e930f798e6ff7ff044ccb4e1b7dca
+    - author:
+        email: krishnagokula5e@gmail.com
+        name: Gokula Krishna
+      branch: master
+      committer:
+        email: krishnagokula5e@gmail.com
+        name: Gokula Krishna
+      message: |
+        chore: Jenkins X build pack
+      sha: be59b27405bfb85b13bac868aa477718b61ec45f
+  gitHttpUrl: https://github.com/gokula-krishna-dev/py-jx
+  gitOwner: gokula-krishna-dev
+  gitRepository: py-jx
+  name: 'py-jx'
+  releaseNotesURL: https://github.com/gokula-krishna-dev/py-jx/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/py-jx/py-jx-ingress.yaml
+++ b/config-root/namespaces/jx-staging/py-jx/py-jx-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: py-jx/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: py-jx
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: py-jx
+              servicePort: 80
+      host: py-jx-jx-staging.192.168.99.114.nip.io

--- a/config-root/namespaces/jx-staging/py-jx/py-jx-py-jx-deploy.yaml
+++ b/config-root/namespaces/jx-staging/py-jx/py-jx-py-jx-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: py-jx/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: py-jx-py-jx
+  labels:
+    draft: draft-app
+    chart: "py-jx-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: py-jx-py-jx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: py-jx-py-jx
+    spec:
+      serviceAccountName: py-jx-py-jx
+      containers:
+        - name: py-jx
+          image: "10.104.74.249/gokula-krishna-dev/py-jx:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/py-jx/py-jx-py-jx-sa.yaml
+++ b/config-root/namespaces/jx-staging/py-jx/py-jx-py-jx-sa.yaml
@@ -1,0 +1,8 @@
+# Source: py-jx/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: py-jx-py-jx
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/py-jx/py-jx-svc.yaml
+++ b/config-root/namespaces/jx-staging/py-jx/py-jx-svc.yaml
@@ -1,0 +1,21 @@
+# Source: py-jx/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: py-jx
+  labels:
+    chart: "py-jx-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: py-jx-py-jx

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,13 +13,10 @@ releases:
   name: golang-gk
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/py-jx
   version: 0.0.1
   name: py-jx
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,13 @@ releases:
   name: golang-gk
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/py-jx
+  version: 0.0.1
+  name: py-jx
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote py-jx to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge